### PR TITLE
Docs: the embed widget does not share booking-logic.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,17 @@ behaviour or markup must usually be made in all three, or they drift:
   implemented separately in each. If you change calendar *behaviour*, update all three.
 - Verify on **desktop and mobile** for each surface after touching the calendar.
 - **Shared slot logic lives in `internal/handler/assets/booking-logic.js`** (tested with
-  `node --test`), not per-surface: day grouping, time formatting, and the taken-slot
-  merge. Put anything all three need there rather than writing it three times.
+  `node --test`): day grouping, time formatting, and the taken-slot merge. It is inlined
+  into **book.html and manage.html only**, which are the two surfaces that load it.
+- ⛔ **The embed widget does NOT load `booking-logic.js`, so `BookingLogic` is undefined
+  inside it.** `EmbedJS` serves `embed.js` as its own standalone file, unmodified — it is a
+  Shadow-DOM web component on a third-party page, with no build step and nothing to
+  prepend the module for it. It therefore carries its own copies of the few helpers it
+  needs (`dowLabels`, `dayKey`, `timeLabel`, `shortDay`, `ymd`), each commented as
+  mirroring the shared one. Calling `BookingLogic.anything` from `embed.js` throws a
+  `ReferenceError` on the customer's site, where no test here would see it. So: put logic
+  the pages share in `booking-logic.js`, and when the widget needs it too, mirror it there
+  deliberately and keep the two in step.
 - **Taken/booked slots** (`show_taken_slots`, off by default) are computed by
   `slots.GenerateWithTaken` as the *difference* between a normal pass and one ignoring
   busy, which is what keeps out-of-hours and min-notice starts from being mislabelled as


### PR DESCRIPTION
## `CLAUDE.md` tells an agent the embed widget shares `booking-logic.js`. It does not.

The booking-calendar section lists three surfaces and then says shared slot logic "lives in
`internal/handler/assets/booking-logic.js` … not per-surface: … Put anything all three need
there rather than writing it three times."

Following that and calling `BookingLogic` from `embed.js` throws a `ReferenceError` on the
customer's site, where nothing in this repo would catch it. We came close to shipping
exactly that.

Checked rather than assumed:

- `embed_handler.go` embeds `embed.js` with `//go:embed` and serves the bytes unmodified
  (`http.ServeContent` over `bytes.NewReader(embedJS)`). Nothing prepends the module.
- `bookingLogicJS` is referenced only by `book.go` and `manage_handler.go`, which inline it
  into their templates.
- `embed.js`'s own comment already says the widget "doesn't import that module", and it
  carries local `dowLabels`, `dayKey`, `timeLabel`, `shortDay` and `ymd` for that reason.

## The change

`CLAUDE.md` only, 11 lines. The entry now names the two surfaces that load the module,
states plainly that `BookingLogic` is undefined in the widget and why (standalone file,
Shadow-DOM component on a third-party page, no build step), and gives the rule: put shared
page logic in `booking-logic.js`, and mirror it into the widget deliberately when the widget
needs it too.

`docs/ARCHITECTURE.md` §8 and the module's own header make the same claim. Those are
corrected in the branch behind #23, so this PR deliberately stays out of their way and
touches neither — the two can merge in either order.

`go test ./...` green, `gofmt -l .` empty, `go vet ./...` clean (nothing executable changed).
